### PR TITLE
Bump aws-java-sdk-bom from 1.11.394 to 1.12.327

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <httpclient.version>4.5.13</httpclient.version>
     <jacoco.version>0.8.4</jacoco.version>
     <jacoco.skip.instrument>true</jacoco.skip.instrument>
-    <awssdk.version>1.11.394</awssdk.version>
+    <awssdk.version>1.12.327</awssdk.version>
     <google.api.client.version>1.34.0</google.api.client.version>
     <google.http.client.version>1.41.4</google.http.client.version>
     <bouncycastle.version>1.70</bouncycastle.version>


### PR DESCRIPTION
Update dependency to remove CVEs:
CVE-2022-31159
CVE-2020-28491