### PR TITLE
Remove maven-failsafe-plugin, exec-maven-plugin, plexus-archiver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,12 +90,6 @@
       <version>9.21</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-failsafe-plugin</artifactId>
-      <version>3.0.0-M1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>
@@ -214,18 +208,6 @@
       <version>1.10.0</version>
       <type>jar</type>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.mojo</groupId>
-      <artifactId>exec-maven-plugin</artifactId>
-      <version>1.2.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-archiver</artifactId>
-      <version>4.3.0</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.yammer.metrics</groupId>


### PR DESCRIPTION
- Remove exec-maven-plugin dependency for hygiene/security. In as both a dependency and plugin, and vulnerable to CVE-2017-1000487.
- Remove maven-failsafe-plugin dependency for hygiene. In as both a dependency and plugin.
- Remove plexus-archiver dependency for hygiene. Not needed on its own.